### PR TITLE
fix: an overflow bug for div2_round

### DIFF
--- a/imagecore/utils/mathutils.h
+++ b/imagecore/utils/mathutils.h
@@ -23,6 +23,7 @@
  */
 
 #pragma once
+#include <climits>
 
 #include "imagecore/imagecore.h"
 
@@ -111,5 +112,8 @@ inline void swap(unsigned int& a, unsigned int& b)
 
 inline unsigned int div2_round(unsigned int a)
 {
-	return (a + 1) / 2;
+	if (a == UINT_MAX)
+		return (a - 1) / 2 + 1;
+	else
+		return (a + 1) / 2;
 }

--- a/imagecore/utils/mathutils.h
+++ b/imagecore/utils/mathutils.h
@@ -23,6 +23,7 @@
  */
 
 #pragma once
+
 #include <climits>
 
 #include "imagecore/imagecore.h"
@@ -112,7 +113,7 @@ inline void swap(unsigned int& a, unsigned int& b)
 
 inline unsigned int div2_round(unsigned int a)
 {
-	if (a == UINT_MAX) {
+	if(a == UINT_MAX) {
 		return (a - 1) / 2 + 1;
 	} else {
 		return (a + 1) / 2;

--- a/imagecore/utils/mathutils.h
+++ b/imagecore/utils/mathutils.h
@@ -24,9 +24,8 @@
 
 #pragma once
 
-#include <climits>
-
 #include "imagecore/imagecore.h"
+#include <climits>
 
 inline float lerp(float a, float b, float v)
 {

--- a/imagecore/utils/mathutils.h
+++ b/imagecore/utils/mathutils.h
@@ -112,8 +112,9 @@ inline void swap(unsigned int& a, unsigned int& b)
 
 inline unsigned int div2_round(unsigned int a)
 {
-	if (a == UINT_MAX)
+	if (a == UINT_MAX) {
 		return (a - 1) / 2 + 1;
-	else
+	} else {
 		return (a + 1) / 2;
+	}
 }


### PR DESCRIPTION
There is a potential overflow bug for div2_round function.

When parameter a of function div2_round (in vireo/imagecore/utils/mathutils.h) has the maximum value, the result is 0 which is incorrect.