### PR TITLE
Re-factor post-increments to pre-increments and reserve where performace will increase.

### DIFF
--- a/imagecore/formats/reader.cpp
+++ b/imagecore/formats/reader.cpp
@@ -43,13 +43,13 @@ int ImageReader::registerReader(ImageReader::Factory* factory)
 {
 	ASSERT(s_NumReaderFactories < MAX_FORMATS);
 	s_ReaderFactories[s_NumReaderFactories] = factory;
-	s_NumReaderFactories++;
+	++s_NumReaderFactories;
 	return s_NumReaderFactories;
 }
 
 ImageReader* ImageReader::createFromSignature(const uint8_t* sig)
 {
-	for( unsigned int i = 0; i < s_NumReaderFactories; i++ ) {
+	for( unsigned int i = 0; i < s_NumReaderFactories; ++i ) {
 		if( s_ReaderFactories[i]->matchesSignature(sig, SIGNATURE_MAX_SIZE) ) {
 			return s_ReaderFactories[i]->create();
 		}
@@ -243,7 +243,7 @@ bool ImageReader::FileStorage::peekSignature(uint8_t* signature)
 			return true;
 		} else {
 			// Can't seek back, probably stdin. Put the signature back into the stream buffer.
-			for( int i = 0; i < SIGNATURE_MAX_SIZE; i++ ) {
+			for( int i = 0; i < SIGNATURE_MAX_SIZE; ++i ) {
 				int b = fgetc(m_File);
 				if( b != EOF ) {
 					signature[i] = b;
@@ -251,7 +251,7 @@ bool ImageReader::FileStorage::peekSignature(uint8_t* signature)
 					return false;
 				}
 			}
-			for( int i = SIGNATURE_MAX_SIZE - 1; i >= 0; i-- ) {
+			for( int i = SIGNATURE_MAX_SIZE - 1; i >= 0; --i ) {
 				ungetc(signature[i], m_File);
 			}
 		}

--- a/imagecore/formats/writer.cpp
+++ b/imagecore/formats/writer.cpp
@@ -45,7 +45,7 @@ int ImageWriter::registerWriter(ImageWriter::Factory* factory)
 {
 	ASSERT(s_NumWriterFactories < MAX_FORMATS);
 	s_WriterFactories[s_NumWriterFactories] = factory;
-	s_NumWriterFactories++;
+	++s_NumWriterFactories;
 	return s_NumWriterFactories;
 }
 
@@ -59,7 +59,7 @@ EImageFormat ImageWriter::formatFromExtension(const char* filename, EImageFormat
 			lastDotStr = nextDotStr + 1;
 		}
 	} while (nextDotStr != NULL);
-	for( unsigned int i = 0; i < s_NumWriterFactories; i++ ) {
+	for( unsigned int i = 0; i < s_NumWriterFactories; ++i ) {
 		if( s_WriterFactories[i]->matchesExtension(lastDotStr) ) {
 			return s_WriterFactories[i]->getFormat();
 		}
@@ -89,14 +89,14 @@ ImageWriter* ImageWriter::createWithFormat(EImageFormat imageFormat, ImageWriter
 ImageWriter::Factory* ImageWriter::factoryForFormat(EImageFormat imageFormat)
 {
 	// First try to find an exact match.
-	for( unsigned int i = 0; i < s_NumWriterFactories; i++ ) {
+	for( unsigned int i = 0; i < s_NumWriterFactories; ++i ) {
 		if( s_WriterFactories[i]->getFormat() == imageFormat ) {
 			return s_WriterFactories[i];
 		}
 	}
 
 	// Then try to find a fallback.
-	for( unsigned int i = 0; i < s_NumWriterFactories; i++ ) {
+	for( unsigned int i = 0; i < s_NumWriterFactories; ++i ) {
 		if( s_WriterFactories[i]->appropriateForInputFormat(imageFormat) ) {
 			return s_WriterFactories[i];
 		}

--- a/imagecore/image/colorpalette.cpp
+++ b/imagecore/image/colorpalette.cpp
@@ -78,8 +78,8 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 
 	START_CLOCK(ColorConversionHistogram);
 
-	for( unsigned int y = 0; y < height; y++ ) {
-		for( unsigned int x = 0; x < width; x++ ) {
+	for( unsigned int y = 0; y < height; ++y ) {
+		for( unsigned int x = 0; x < width; ++x ) {
 			const RGBA* rgba = (RGBA*)(&buffer[y * framePitch + x * 4]);
 			if (useHsv) {
 				floatImage[y * width + x] = ColorSpace::srgbToHsv(ColorSpace::byteToFloat(*rgba));
@@ -108,17 +108,17 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 	std::vector<int> vAreaMaxY;
 	std::vector<int> vAreaMaxZ;
 
-	for( int i = 0; i < numColors; i++ ) {
+	for( int i = 0; i < numColors; ++i ) {
 		int areaMaxX = 0;
 		int areaMaxY = 0;
 		int areaMaxZ = 0;
 		float maxAreaSum = 0.0f;
 
-		for( int x = 0; x < kHistSize; x++ ) {
-			for( int y = 0; y < kHistSize; y++ ) {
-				for( int z = 0; z < kHistSize; z++ ) {
+		for( int x = 0; x < kHistSize; ++x ) {
+			for( int y = 0; y < kHistSize; ++y ) {
+				for( int z = 0; z < kHistSize; ++z ) {
 					float sum = 0;
-					for( int sx = -searchSizeX; sx <= searchSizeX; sx++ ) {
+					for( int sx = -searchSizeX; sx <= searchSizeX; ++sx ) {
 						int wrappedX = x + sx;
 						if (useHsv) {
 							// Hue in HSV is circular, so we wrap instead of clamp.
@@ -128,9 +128,9 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 								wrappedX = kHistSize + wrappedX - 1;
 							}
 						}
-						for( int sy = -searchSizeY; sy <= searchSizeY; sy++ ) {
+						for( int sy = -searchSizeY; sy <= searchSizeY; ++sy ) {
 							int index = INDEX_HIST(wrappedX, y + sy, z);
-							for( int sz = -searchSizeZ; sz <= searchSizeZ; sz++ ) {
+							for( int sz = -searchSizeZ; sz <= searchSizeZ; ++sz ) {
 								sum += histogram[index + sz];
 							}
 						}
@@ -150,7 +150,7 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 			vAreaMaxY.push_back(areaMaxY);
 			vAreaMaxZ.push_back(areaMaxZ);
 			if( numColors > 1 ) {
-				for( int sx = -searchSizeX; sx <= searchSizeX; sx++ ) {
+				for( int sx = -searchSizeX; sx <= searchSizeX; ++sx ) {
 					int wrappedX = areaMaxX + sx;
 					if( useHsv ) {
 						// Hue in HSV is circular, so we wrap instead of clamp.
@@ -160,9 +160,9 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 							wrappedX = kHistSize + wrappedX - 1;
 						}
 					}
-					for( int sy = -searchSizeY; sy <= searchSizeY; sy++ ) {
+					for( int sy = -searchSizeY; sy <= searchSizeY; ++sy ) {
 						int index = INDEX_HIST(wrappedX, areaMaxY + sy, areaMaxZ);
-						for( int sz = -searchSizeZ; sz <= searchSizeZ; sz++ ) {
+						for( int sz = -searchSizeZ; sz <= searchSizeZ; ++sz ) {
 							histogram[index + sz] = -fabs(histogram[index + sz]);
 						}
 					}
@@ -180,7 +180,7 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 	WeightedColor* weightedColors = (WeightedColor*)malloc(numColors * sizeof(WeightedColor));
 
 	SECURE_ASSERT(vAreaMaxX.size() == vAreaMaxY.size() && vAreaMaxX.size() == vAreaMaxZ.size());
-	for( int m = 0; m < min((int)vAreaMaxX.size(), numColors); m++ ) {
+	for( int m = 0; m < min((int)vAreaMaxX.size(), numColors); ++m ) {
 		int areaMaxX = vAreaMaxX[m];
 		int areaMaxY = vAreaMaxY[m];
 		int areaMaxZ = vAreaMaxZ[m];
@@ -192,8 +192,8 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 		int gAvg = 0;
 		int bAvg = 0;
 		int mmax = 0;
-		for( unsigned int y = 0; y < height; y++ ) {
-			for( unsigned int x = 0; x < width; x++ ) {
+		for( unsigned int y = 0; y < height; ++y ) {
+			for( unsigned int x = 0; x < width; ++x ) {
 				const RGBA* rgba = (RGBA*)(&buffer[y * framePitch + x * 4]);
 				const float3& c = floatImage[y * width + x];
 				int hx = clamp(0, kHistSize - 1, (int)(c.x * (float)kHistSize));
@@ -208,7 +208,7 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 					gDim.push_back(rgba->g);
 					bDim.push_back(rgba->b);
 					colors.push_back(*rgba);
-					mmax++;
+					++mmax;
 				}
 			}
 		}
@@ -227,7 +227,7 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 			RGBA outColor(0, 0, 0, 255);
 
 			int closestColorDist = 10000000;
-			for( unsigned i = 0; i < colors.size(); i++ ) {
+			for( unsigned i = 0; i < colors.size(); ++i ) {
 				const RGBA& c = colors.at(i);
 				float dr = c.r - medianR;
 				float dg = c.g - medianG;
@@ -242,13 +242,13 @@ static int computeHistogram(ImageRGBA* frameImage, RGBA* ccolors, double* colorP
 					}
 				}
 			}
-			numOutColors++;
+			++numOutColors;
 		}
 	}
 
 	std::sort(weightedColors, weightedColors + numOutColors);
 
-	for( int i = 0; i < numOutColors; i++ ) {
+	for( int i = 0; i < numOutColors; ++i ) {
 		ccolors[i] = weightedColors[numOutColors - i - 1].color;
 		colorPct[i] = weightedColors[numOutColors - i - 1].pct;
 	}
@@ -294,16 +294,17 @@ struct colorSample {
 
 static vector<colorSample> initializeCentroids(unsigned int numCluster, vector<colorSample>& samples) {
 	vector<colorSample> centroids;
+	centroids.reserve(numCluster); // because we know how many elements get put in.
 	uint64_t size = samples.size();
 	// initialize using random samples in the image
 	srand(817504253); // feed a fixed prime seed for deterministic results and easy testing
-	for( unsigned int k = 0; k < numCluster; k++ ) {
+	for( unsigned int k = 0; k < numCluster; ++k ) {
 		uint64_t randomIdx = rand() % size;
 		unsigned int count = 0;
-		for( unsigned int i = 0; i < k; i++ ) {
+		for( unsigned int i = 0; i < k; ++i ) {
 			while( samples[randomIdx].rgba == centroids[i].rgba && count < 10 ) { // get rid of same colors as initial centroids, but do not try too hard
 				randomIdx = rand() % size;
-				count++;
+				++count;
 			}
 		}
 		samples[randomIdx].label = k;
@@ -348,7 +349,7 @@ static vector<colorSample> getCentroids(vector<colorSample> samples, unsigned in
 	}
 
 	vector<colorSample> centroids;
-	for( unsigned int k = 0; k < numCluster; k++ ) {
+	for( unsigned int k = 0; k < numCluster; ++k ) {
 		float3 lab(sums[k].x / clusterSize[k], sums[k].y / clusterSize[k], sums[k].z / clusterSize[k]);
 		RGBA rgba = ColorSpace::floatToByte(ColorSpace::labToSrgb(lab));
 		centroids.push_back(colorSample(rgba, lab, k, 0));
@@ -366,8 +367,8 @@ static int computeKmeans(imagecore::ImageRGBA *frameImage, unsigned int numClust
 	uint8_t* buffer = frameImage->lockRect(width, height, framePitch);
 
 	// get all the samples (whose alpha value is > 128)
-	for( unsigned int y = 0; y < height; y++ ) {
-		for( unsigned int x = 0; x < width; x++ ) {
+	for( unsigned int y = 0; y < height; ++y ) {
+		for( unsigned int x = 0; x < width; ++x ) {
 			const RGBA rgba = *(RGBA*)(&buffer[y * framePitch + x * 4]);
 			if( rgba.a > 128 ) {
 				float3 lab = ColorSpace::srgbToLab(ColorSpace::byteToFloat(rgba));
@@ -380,12 +381,12 @@ static int computeKmeans(imagecore::ImageRGBA *frameImage, unsigned int numClust
 
 	vector<colorSample> centroids = initializeCentroids(numCluster, samples);
 	// main loop for k-means clustering
-	for( unsigned int iteration = 0; iteration < MAX_ITERATIONS; iteration++ ) {
+	for( unsigned int iteration = 0; iteration < MAX_ITERATIONS; ++iteration ) {
 		sampleLabeling(samples, centroids);
 		vector<colorSample> newCentroids = getCentroids(samples, numCluster);
 		//if newCentroids are closed enough to old centroids, stop iteration
 		bool closeEnough = true;
-		for( unsigned int k = 0; k < numCluster; k++ ) {
+		for( unsigned int k = 0; k < numCluster; ++k ) {
 			if( squaredDist(centroids[k], newCentroids[k]) > DELTA_LIMIT ) {
 				closeEnough = false;
 			}
@@ -401,7 +402,7 @@ static int computeKmeans(imagecore::ImageRGBA *frameImage, unsigned int numClust
 	unsigned int numOutColors = 0;
 	colorPalette[numOutColors] = centroids[numCluster-1].rgba;
 	colorPct[numOutColors] = (double)centroids[numCluster - 1].clusterSize / totalSize;
-	for( int k = numCluster - 2; k >= 0; k-- ) {
+	for( int k = numCluster - 2; k >= 0; --k ) {
 		double pct = (double)centroids[k].clusterSize / totalSize;
 		if( pct < 0.001f)  {
 			continue;
@@ -409,7 +410,7 @@ static int computeKmeans(imagecore::ImageRGBA *frameImage, unsigned int numClust
 		if( centroids[k].rgba == colorPalette[numOutColors] ) {
 			colorPct[numOutColors] += pct;
 		} else {
-			numOutColors++;
+			++numOutColors;
 			colorPalette[numOutColors] = centroids[k].rgba;
 			colorPct[numOutColors] = pct;
 		}

--- a/imagecore/image/image.cpp
+++ b/imagecore/image/image.cpp
@@ -311,8 +311,8 @@ IMAGEPLANE(void)::fillPadding(EEdgeMask edgeMask)
 		typename primType::asType* sample = (typename primType::asType*)lockRect(m_Width, m_Height, pitch);
 		int componentPitch = pitch / Channels;
 		if( (edgeMask & kEdge_Left) != 0 && (m_PadRegionDirty & kEdge_Left) != 0 ) {
-			for( int y = 0; y < m_Height; y++ ) {
-				for( int x = -m_Padding; x < 0; x++ ) {
+			for( int y = 0; y < m_Height; ++y ) {
+				for( int x = -m_Padding; x < 0; ++x ) {
 					sample[y * componentPitch + x] = sample[y * componentPitch + 0];
 				}
 			}
@@ -320,8 +320,8 @@ IMAGEPLANE(void)::fillPadding(EEdgeMask edgeMask)
 		}
 		if( (edgeMask & kEdge_Right) != 0 && (m_PadRegionDirty & kEdge_Right) != 0 ) {
 			unsigned int paddedWidth = m_Width + m_Padding;
-			for( int y = 0; y < m_Height; y++ ) {
-				for( int x = m_Width; x < paddedWidth; x++ ) {
+			for( int y = 0; y < m_Height; ++y ) {
+				for( int x = m_Width; x < paddedWidth; ++x ) {
 					sample[y * componentPitch + x] = sample[y * componentPitch + (m_Width - 1)];
 				}
 			}
@@ -329,7 +329,7 @@ IMAGEPLANE(void)::fillPadding(EEdgeMask edgeMask)
 		}
 		if( (edgeMask & kEdge_Top) != 0 && (m_PadRegionDirty & kEdge_Top) != 0 ) {
 			unsigned int twicePaddedWidth = m_Width + m_Padding * 2;
-			for( int y = -m_Padding; y < 0; y++ ) {
+			for( int y = -m_Padding; y < 0; ++y ) {
 				memcpy(sample + y * componentPitch - m_Padding, sample + 0 * componentPitch - m_Padding, twicePaddedWidth * Channels);
 			}
 			m_PadRegionDirty &= ~kEdge_Top;
@@ -337,7 +337,7 @@ IMAGEPLANE(void)::fillPadding(EEdgeMask edgeMask)
 		if( (edgeMask & kEdge_Bottom) != 0 && (m_PadRegionDirty & kEdge_Bottom) != 0 ) {
 			unsigned int paddedHeight = m_Height + m_Padding;
 			unsigned int twicePaddedWidth = m_Width + m_Padding * 2;
-			for( int y = m_Height; y < paddedHeight; y++ ) {
+			for( int y = m_Height; y < paddedHeight; ++y ) {
 				memcpy(sample + y * componentPitch - m_Padding, sample + (m_Height - 1) * componentPitch - m_Padding, twicePaddedWidth * Channels);
 			}
 			m_PadRegionDirty &= ~kEdge_Bottom;
@@ -526,8 +526,8 @@ IMAGEPLANE(void)::clearRect(unsigned int sx, unsigned int sy, unsigned int w, un
 {
 	unsigned int destPitch = 0;
 	uint8_t* destBuffer = lockRect(sx, sy, w, h, destPitch);
-	for( unsigned int y = 0; y < h; y++ ) {
-		for( unsigned int x = 0; x < w; x++ ) {
+	for( unsigned int y = 0; y < h; ++y ) {
+		for( unsigned int x = 0; x < w; ++x ) {
 			unsigned int outIndex = y * destPitch + x * Channels;
 			*(typename primType::asType*)&destBuffer[outIndex + 0] = component;
 		}
@@ -549,7 +549,7 @@ IMAGEPLANE(void)::copyRect(ImagePlane<Channels>* dest, unsigned int sourceX, uns
 	uint8_t* sourceBuffer = lockRect(sourceX, sourceY, width, height, sourcePitch);
 	unsigned int destPitch = 0;
 	uint8_t* destBuffer = dest->lockRect(destX, destY, width, height, destPitch);
-	for( unsigned int y = 0; y < height; y++ ) {
+	for( unsigned int y = 0; y < height; ++y ) {
 		memcpy(destBuffer + y * destPitch, sourceBuffer + y * sourcePitch, width * Channels);
 	}
 }

--- a/imagecore/image/kernel.cpp
+++ b/imagecore/image/kernel.cpp
@@ -157,7 +157,7 @@ void FilterKernel::generateFixedPoint(EFilterType type)
 	if(type == kFilterType_Linear) {
 		m_TableBilinear = new uint8_t[tableSize];
 		// Convert to fixed point.
-		for( unsigned int i = 0; i < tableSize; i++ ) {
+		for( unsigned int i = 0; i < tableSize; ++i ) {
 			m_TableBilinear[i] = (int)(m_Table[i] * 255.0f);
 		}
 	} else {
@@ -165,7 +165,7 @@ void FilterKernel::generateFixedPoint(EFilterType type)
 		m_TableFixedPoint4 = new int32_t[SafeUMul(tableSize, 4U)];
 		// Convert to fixed point.
 		// This is duplicated 4 times to save a few SSE instructions.
-		for( unsigned int i = 0; i < tableSize; i++ ) {
+		for( unsigned int i = 0; i < tableSize; ++i ) {
 			int value = (int)(m_Table[i] * 65536.0f);
 			m_TableFixedPoint[i] = value;
 			m_TableFixedPoint4[i * 4 + 0] = value;
@@ -210,7 +210,7 @@ FilterKernelAdaptive::FilterKernelAdaptive(EFilterType type, unsigned int kernel
 	FilterFunction filterFunction = s_FilterFunctionsAdaptive[type];
 	int maxSamples = 0;
 	if (type == kFilterType_Linear) {
-		for( unsigned int i = 0; i < outSize; i++ ) {
+		for( unsigned int i = 0; i < outSize; ++i ) {
 			float sample = (i + 0.5f) * invRatio;
 			float w0 = sample - floorf(sample);
 			m_Table[i * kernelSize + 0] = 1.0f - w0;
@@ -219,24 +219,24 @@ FilterKernelAdaptive::FilterKernelAdaptive(EFilterType type, unsigned int kernel
 		m_WindowWidth = 0.5f;
 		maxSamples = 2;
 	} else {
-		for( unsigned int i = 0; i < outSize; i++ ) {
+		for( unsigned int i = 0; i < outSize; ++i ) {
 			float sample = (i + 0.5f) * invRatio - 0.00001f;
 			int start = sample - windowWidth + 0.5f;
 			int end = sample + windowWidth + 0.5f;
 			int numSamples = end - start;
 			maxSamples = max(maxSamples, numSamples);
 			float sum = 0.0f;
-			for( int k = 0; k < numSamples; k++ ) {
+			for( int k = 0; k < numSamples; ++k ) {
 				float samplePos = ratio * ((float)(start + k) - sample + 0.5f);
 				float weight = filterFunction(samplePos, invFilterScale);
 				m_Table[i * kernelSize + k] = weight;
 				sum += weight;
 			}
-			for( unsigned int k = numSamples; k < kernelSize; k++ ) {
+			for( unsigned int k = numSamples; k < kernelSize; ++k ) {
 				m_Table[i * kernelSize + k] = 0.0f;
 			}
 			float invSum = 1.0f / sum;
-			for (int k = 0; k < numSamples; k++) {
+			for (int k = 0; k < numSamples; ++k) {
 				m_Table[i * kernelSize + k] *= invSum;
 			}
 		}
@@ -256,7 +256,7 @@ FilterKernelFixed::FilterKernelFixed(EFilterType type, unsigned int inSize, unsi
 	m_WindowWidth = 4;
 	FilterFunction filterFunction = s_FilterFunctionsFixed[type];
 	m_SampleRatio = (float)inSize / (float)outSize;
-	for( unsigned int i = 0; i < outSize; i++ ) {
+	for( unsigned int i = 0; i < outSize; ++i ) {
 		float inP = fmaxf(0.0f, ((float)(i + 0.5f) * m_SampleRatio) - 0.5f);
 		float frP = inP - floorf(inP);
 		float a = filterFunction(frP + 1.0f, 4);

--- a/imagecore/image/resizecrop.cpp
+++ b/imagecore/image/resizecrop.cpp
@@ -54,7 +54,7 @@ ResizeCropOperation::ResizeCropOperation()
 
 ResizeCropOperation::~ResizeCropOperation()
 {
-	for( unsigned int i = 0; i < 2; i++ ) {
+	for( unsigned int i = 0; i < 2; ++i ) {
 		if( m_FilteredImage[i] != NULL ) {
 			delete m_FilteredImage[i];
 			m_FilteredImage[i] = NULL;
@@ -244,8 +244,8 @@ int ResizeCropOperation::fillBackground()
 		unsigned int width = image->getWidth();
 		unsigned int height = image->getHeight();
 		uint8_t* buffer = image->lockRect(width, height, framePitch);
-		for( unsigned int y = 0; y < height; y++ ) {
-			for( unsigned int x = 0; x < width; x++ ) {
+		for( unsigned int y = 0; y < height; ++y ) {
+			for( unsigned int x = 0; x < width; ++x ) {
 				RGBA* rgba = (RGBA*)(&buffer[y * framePitch + x * 4]);
 				if( rgba->a == 0 ) {
 					*rgba = ColorSpace::floatToByte(fillColor);

--- a/imagecore/image/rgba.cpp
+++ b/imagecore/image/rgba.cpp
@@ -86,8 +86,8 @@ bool ImageRGBA::scanAlpha()
 	unsigned int width = m_ImagePlane->getWidth();
 	unsigned int height = m_ImagePlane->getHeight();
 	uint8_t* buffer = m_ImagePlane->lockRect(width, height, framePitch);
-	for( unsigned int y = 0; y < height; y++ ) {
-		for( unsigned int x = 0; x < width; x++ ) {
+	for( unsigned int y = 0; y < height; ++y ) {
+		for( unsigned int x = 0; x < width; ++x ) {
 			const RGBA* c = (RGBA*)(&buffer[y * framePitch + x * 4]);
 			if( c->a != 255 )
 			{

--- a/imagecore/image/yuv.cpp
+++ b/imagecore/image/yuv.cpp
@@ -204,15 +204,15 @@ void ImageYUV::applyLookupTable(ImageYUV* destImage, uint8_t* tableY, uint8_t* t
 	uint8_t* destBufferY = destImage->getPlaneY()->lockRect(widthY, heightY, destPitchY);
 
 	if( destPitchY == pitchY ) {
-		for( unsigned int y = 0; y < heightY; y++ ) {
-			for( unsigned int x = 0; x < widthY; x++ ) {
+		for( unsigned int y = 0; y < heightY; ++y ) {
+			for( unsigned int x = 0; x < widthY; ++x ) {
 				unsigned int offset = (y * pitchY) + x;
 				destBufferY[offset] = tableY[bufferY[offset]];
 			}
 		}
 	} else {
-		for( unsigned int y = 0; y < heightY; y++ ) {
-			for( unsigned int x = 0; x < widthY; x++ ) {
+		for( unsigned int y = 0; y < heightY; ++y ) {
+			for( unsigned int x = 0; x < widthY; ++x ) {
 				destBufferY[(y * destPitchY) + x] = tableY[bufferY[(y * pitchY) + x]];
 			}
 		}
@@ -228,16 +228,16 @@ void ImageYUV::applyLookupTable(ImageYUV* destImage, uint8_t* tableY, uint8_t* t
 	uint8_t* destBufferV = destImage->getPlaneV()->lockRect(widthUV, heightUV, destPitchUV);
 
 	if( destPitchY == pitchY ) {
-		for( unsigned int y = 0; y < heightUV; y++ ) {
-			for( unsigned int x = 0; x < widthUV; x++ ) {
+		for( unsigned int y = 0; y < heightUV; ++y ) {
+			for( unsigned int x = 0; x < widthUV; ++x ) {
 				unsigned int offset = (y * pitchUV) + x;
 				destBufferU[offset] = tableUV[bufferU[offset]];
 				destBufferV[offset] = tableUV[bufferV[offset]];
 			}
 		}
 	} else {
-		for( unsigned int y = 0; y < heightUV; y++ ) {
-			for( unsigned int x = 0; x < widthUV; x++ ) {
+		for( unsigned int y = 0; y < heightUV; ++y ) {
+			for( unsigned int x = 0; x < widthUV; ++x ) {
 				unsigned int inOffset = (y * pitchUV) + x;
 				unsigned int outOffset = (y * destPitchUV) + x;
 				destBufferU[outOffset] = tableUV[bufferU[inOffset]];
@@ -258,7 +258,7 @@ void ImageYUV::compressRange(ImageYUV* destImage)
 	static uint8_t invTableY[255];
 	static uint8_t invTableUV[255];
 	if( !didInitTable ) {
-		for( int i = 0; i < 256; i++ ) {
+		for( int i = 0; i < 256; ++i ) {
 			invTableY[i] = clamp(0, 255, floor(0.5f + lerp(16.0f, 235.0f, i / 255.0f)));
 			invTableUV[i] = clamp(0, 255, floor(0.5f + lerp(16.0f, 240.0f, i / 255.0f)));
 		}
@@ -279,7 +279,7 @@ void ImageYUV::expandRange(ImageYUV *destImage)
 	static uint8_t tableY[255];
 	static uint8_t tableUV[255];
 	if( !didInitTable ) {
-		for( int i = 0; i < 256; i++ ) {
+		for( int i = 0; i < 256; ++i ) {
 			tableY[i] = clamp(0, 255, floor(0.5f + step(16.0f, 235.0f, i) * 255.0f));
 			tableUV[i] = clamp(0, 255, floor(0.5f + step(16.0f, 240.0f, i) * 255.0f));
 		}

--- a/imagecore/image/yuv_semiplanar.cpp
+++ b/imagecore/image/yuv_semiplanar.cpp
@@ -248,15 +248,15 @@ void ImageYUVSemiplanar::applyLookupTable(ImageYUVSemiplanar* destImage, uint8_t
 	uint8_t* destBufferY = destImage->getPlaneY()->lockRect(widthY, heightY, destPitchY);
 
 	if( destPitchY == pitchY ) {
-		for( unsigned int y = 0; y < heightY; y++ ) {
-			for( unsigned int x = 0; x < widthY; x++ ) {
+		for( unsigned int y = 0; y < heightY; ++y ) {
+			for( unsigned int x = 0; x < widthY; ++x ) {
 				unsigned int offset = (y * pitchY) + x;
 				destBufferY[offset] = tableY[bufferY[offset]];
 			}
 		}
 	} else {
-		for( unsigned int y = 0; y < heightY; y++ ) {
-			for( unsigned int x = 0; x < widthY; x++ ) {
+		for( unsigned int y = 0; y < heightY; ++y ) {
+			for( unsigned int x = 0; x < widthY; ++x ) {
 				destBufferY[(y * destPitchY) + x] = tableY[bufferY[(y * pitchY) + x]];
 			}
 		}
@@ -270,15 +270,15 @@ void ImageYUVSemiplanar::applyLookupTable(ImageYUVSemiplanar* destImage, uint8_t
 	uint8_t* destBufferUV = destImage->getPlaneUV()->lockRect(widthUV, heightUV, destPitchUV);
 
 	if( destPitchY == pitchY ) {
-		for( unsigned int y = 0; y < heightUV; y++ ) {
-			for( unsigned int x = 0; x < widthUV; x++ ) {
+		for( unsigned int y = 0; y < heightUV; ++y ) {
+			for( unsigned int x = 0; x < widthUV; ++x ) {
 				unsigned int offset = (y * pitchUV) + x;
 				destBufferUV[offset] = tableUV[bufferUV[offset]];
 			}
 		}
 	} else {
-		for( unsigned int y = 0; y < heightUV; y++ ) {
-			for( unsigned int x = 0; x < widthUV; x++ ) {
+		for( unsigned int y = 0; y < heightUV; ++y ) {
+			for( unsigned int x = 0; x < widthUV; ++x ) {
 				unsigned int inOffset = (y * pitchUV) + x;
 				unsigned int outOffset = (y * destPitchUV) + x;
 				destBufferUV[outOffset] = tableUV[bufferUV[inOffset]];
@@ -298,7 +298,7 @@ void ImageYUVSemiplanar::compressRange(ImageYUVSemiplanar* destImage)
 	static uint8_t invTableY[255];
 	static uint8_t invTableUV[255];
 	if( !didInitTable ) {
-		for( int i = 0; i < 256; i++ ) {
+		for( int i = 0; i < 256; ++i ) {
 			invTableY[i] = clamp(0, 255, floor(0.5f + lerp(16.0f, 235.0f, i / 255.0f)));
 			invTableUV[i] = clamp(0, 255, floor(0.5f + lerp(16.0f, 240.0f, i / 255.0f)));
 		}
@@ -319,7 +319,7 @@ void ImageYUVSemiplanar::expandRange(ImageYUVSemiplanar *destImage)
 	static uint8_t tableY[255];
 	static uint8_t tableUV[255];
 	if( !didInitTable ) {
-		for( int i = 0; i < 256; i++ ) {
+		for( int i = 0; i < 256; ++i ) {
 			tableY[i] = clamp(0, 255, floor(0.5f + step(16.0f, 235.0f, i) * 255.0f));
 			tableUV[i] = clamp(0, 255, floor(0.5f + step(16.0f, 240.0f, i) * 255.0f));
 		}


### PR DESCRIPTION
Change all post-increments to pre-increments where necessary to improve performance.

For example consider the following:
```
class Integer {

  public:

  // Sample implementation of pre-incrementing.
  Integer & operator++() {
    myInt += 1;
    return *this;
  }
  // Sample implementation of post-incrementing.
  const Integer operator++(int) {
    Integer temporary = *this;
    ++*this;
    return temporary;
  }

  private:

  int myInt;
};
```

The additional copy (temporary) in post-incrementing step is unnecessary.

Also optimized a vector which was not being reserved even though we knew
the exact number of elements that were going into it.

